### PR TITLE
Add 48 CSV files to Output_tabnet_ateeq (LFS)

### DIFF
--- a/Output_tabnet_ateeq/all_model_preds_t+1.csv
+++ b/Output_tabnet_ateeq/all_model_preds_t+1.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2f324328565b29f4f5c9b391fb0665de98652b809742f6bf764e7df0f818ed73
+size 8049

--- a/Output_tabnet_ateeq/all_model_preds_t+3.csv
+++ b/Output_tabnet_ateeq/all_model_preds_t+3.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a71c308f9e6a44313352e64aefd26a3bcce3d1d49b83cb841bde34c20525110c
+size 8040

--- a/Output_tabnet_ateeq/all_model_preds_t+7.csv
+++ b/Output_tabnet_ateeq/all_model_preds_t+7.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:69f3b47a515d02bb0e6888d874e4f82f13bbbfec80d4d4a21c935910674fd51d
+size 8070

--- a/Output_tabnet_ateeq/baseline_metrics_multi_horizon.csv
+++ b/Output_tabnet_ateeq/baseline_metrics_multi_horizon.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5f15abd350f8a4e215e86a3aa5a0de896f8733d902723187689c2513dca7e116
+size 1113

--- a/Output_tabnet_ateeq/best_tree_learning_curve_h1.csv
+++ b/Output_tabnet_ateeq/best_tree_learning_curve_h1.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:114e663dfcc11d97e4fd889c16ade4547367ae016e771441e1f715b9a606ff66
+size 561

--- a/Output_tabnet_ateeq/best_tree_learning_curve_h3.csv
+++ b/Output_tabnet_ateeq/best_tree_learning_curve_h3.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1c27c981d95bd1f0155ab83a8227f53e129ad5f48dd5e464bd3cc4d23b61a4b2
+size 562

--- a/Output_tabnet_ateeq/best_tree_learning_curve_h7.csv
+++ b/Output_tabnet_ateeq/best_tree_learning_curve_h7.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ea753a0d0239babe8ecfc6b0df174fe6a3940665990bf8399aec2feac7bfcf7b
+size 560

--- a/Output_tabnet_ateeq/conformal_coverage_tabnet.csv
+++ b/Output_tabnet_ateeq/conformal_coverage_tabnet.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b3a095a86fc40747d54d0f0db06d50a28ee17313cba52479c1fbea18980c034b
+size 167

--- a/Output_tabnet_ateeq/data_dictionary.csv
+++ b/Output_tabnet_ateeq/data_dictionary.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:998161f073f74ef8609f58bd07d1c416e9c120fd0a5bfad0b152605b475779b2
+size 1694

--- a/Output_tabnet_ateeq/features_daily.csv
+++ b/Output_tabnet_ateeq/features_daily.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:54e490f60beaeb1544d3d9272a4875f10f4aa600af8e46ccc1561d38ca323e06
+size 310219

--- a/Output_tabnet_ateeq/mega_all_models_all_horizons.csv
+++ b/Output_tabnet_ateeq/mega_all_models_all_horizons.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5960f2c4df29cec5b035f9fa6883f788b9100f643a1b472e5cc943eb04b3b0df
+size 53232

--- a/Output_tabnet_ateeq/mega_color_map.csv
+++ b/Output_tabnet_ateeq/mega_color_map.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:75fe3f6d3cd3d220beeb39567125184fee5dd714aec712e2a7d9c91467861cd9
+size 1493

--- a/Output_tabnet_ateeq/metrics_everything.csv
+++ b/Output_tabnet_ateeq/metrics_everything.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:51deba481f17f96c4989129354ee21ac56e08db19cd00a5150eb98e4943f6d35
+size 2443

--- a/Output_tabnet_ateeq/metrics_with_tabnet.csv
+++ b/Output_tabnet_ateeq/metrics_with_tabnet.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1427e061adb405e6a0299e9aef3aa8635edf7b020ebd24c95274f0ea29b5fa78
+size 1301

--- a/Output_tabnet_ateeq/metrics_with_tabnet_and_multitask.csv
+++ b/Output_tabnet_ateeq/metrics_with_tabnet_and_multitask.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:29b5835168c088088814abb3a53cc87913a4f969e6a92d2fcbe7d8d210f01d43
+size 1499

--- a/Output_tabnet_ateeq/metrics_with_tabnet_transformer.csv
+++ b/Output_tabnet_ateeq/metrics_with_tabnet_transformer.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:758275658df89b23446409e8783294814954793d26b6bf291bc524df7c658e6f
+size 1714

--- a/Output_tabnet_ateeq/preds_best_baseline_t+1.csv
+++ b/Output_tabnet_ateeq/preds_best_baseline_t+1.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:537e4b8e22f167cf54f7504289f19f738d7f90dbfacdb85503471e9b8b96e0c7
+size 1973

--- a/Output_tabnet_ateeq/preds_best_baseline_t+3.csv
+++ b/Output_tabnet_ateeq/preds_best_baseline_t+3.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6f3c30a586772d4f831bef19f4ec34b75d204ef2083125cb601dd25526ce37dd
+size 1984

--- a/Output_tabnet_ateeq/preds_best_baseline_t+7.csv
+++ b/Output_tabnet_ateeq/preds_best_baseline_t+7.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:75ac5e19a7b1a63a742e5f3095fa401f17a318f282e5465e8b6cba711d9beea0
+size 1964

--- a/Output_tabnet_ateeq/preds_lstm_mt_t+1.csv
+++ b/Output_tabnet_ateeq/preds_lstm_mt_t+1.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cd99e8d0a5ff3d1970904c810fb29843be25bd4b927b22a6182dc12e46c374a3
+size 1519

--- a/Output_tabnet_ateeq/preds_lstm_mt_t+3.csv
+++ b/Output_tabnet_ateeq/preds_lstm_mt_t+3.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b366b0f729d11fd718a43e16eccfbe84c983b82662e00e757ca7d536b8251271
+size 1475

--- a/Output_tabnet_ateeq/preds_lstm_mt_t+7.csv
+++ b/Output_tabnet_ateeq/preds_lstm_mt_t+7.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a508b32eb9bf700fcb5d846f739789bed533481885c75cee0125b3abf7dc4a89
+size 1518

--- a/Output_tabnet_ateeq/preds_tabnet_mt_t+1.csv
+++ b/Output_tabnet_ateeq/preds_tabnet_mt_t+1.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5e38e0eb8aae014d7f5beac0668e7e089f48e183b86457abc8c30b04b2fe5a45
+size 1509

--- a/Output_tabnet_ateeq/preds_tabnet_mt_t+3.csv
+++ b/Output_tabnet_ateeq/preds_tabnet_mt_t+3.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a536d2363ab172e3d8b4b6e549eff84257b6e0345bb032579995a25d3ef74524
+size 1545

--- a/Output_tabnet_ateeq/preds_tabnet_mt_t+7.csv
+++ b/Output_tabnet_ateeq/preds_tabnet_mt_t+7.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7982b362034f66400402c2ba061716c572d8eac4b80ed55e5d5f026f3031b7ce
+size 1536

--- a/Output_tabnet_ateeq/preds_tabnet_t+1.csv
+++ b/Output_tabnet_ateeq/preds_tabnet_t+1.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ad92b1f1ac9a23a819e0a188f0d029ea2fb6591c0c18d103037cc6814396f2c6
+size 1505

--- a/Output_tabnet_ateeq/preds_tabnet_t+3.csv
+++ b/Output_tabnet_ateeq/preds_tabnet_t+3.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:601f12dc4f4755574a89a5653e6007e8718c6185bbaed9c772fcc87c403e85b3
+size 1512

--- a/Output_tabnet_ateeq/preds_tabnet_t+7.csv
+++ b/Output_tabnet_ateeq/preds_tabnet_t+7.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7eab5db6916e3365257da9b1c9b68419d5f6efdad2f09ac23b9c8135fd43edcd
+size 1524

--- a/Output_tabnet_ateeq/preds_tabtransformer_t+1.csv
+++ b/Output_tabnet_ateeq/preds_tabtransformer_t+1.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b2744852bd7c65d5566dac01300c2ba4af730ab2e78699f5552aedced9969479
+size 1506

--- a/Output_tabnet_ateeq/preds_tabtransformer_t+3.csv
+++ b/Output_tabnet_ateeq/preds_tabtransformer_t+3.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e6ef407216f542e9f927f1fd9452506bf60d97f95749160c676bfc323df6053b
+size 1506

--- a/Output_tabnet_ateeq/preds_tabtransformer_t+7.csv
+++ b/Output_tabnet_ateeq/preds_tabtransformer_t+7.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:43eab9ab50e786d17299eeb0228ef2d78c42e519133e43c947f980a96114db8e
+size 1498

--- a/Output_tabnet_ateeq/rf_feature_importance.csv
+++ b/Output_tabnet_ateeq/rf_feature_importance.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b062b46bff24fc78af89db2441742f8f85e5cd37aaeff77fcb1886ba53cc822c
+size 1209

--- a/Output_tabnet_ateeq/tabnet_aligned_predictions_all_horizons.csv
+++ b/Output_tabnet_ateeq/tabnet_aligned_predictions_all_horizons.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4e3bdccf8d8b80c3d5af7424b39d96c6cd6b897ffc0fe002169aa2a2a823610b
+size 5452

--- a/Output_tabnet_ateeq/tabnet_dow_mae_all_horizons.csv
+++ b/Output_tabnet_ateeq/tabnet_dow_mae_all_horizons.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:741dde4d2dd0bbe99fed7e25c272026aa8cddc9c84eb3bb195da6a3faf08746d
+size 273

--- a/Output_tabnet_ateeq/tabnet_feature_importance_top20_h1.csv
+++ b/Output_tabnet_ateeq/tabnet_feature_importance_top20_h1.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:877e2d7525c2be34540a72cc304ebb197987cffffa343592fcfadd75c3e121b2
+size 657

--- a/Output_tabnet_ateeq/tabnet_feature_importance_top20_h3.csv
+++ b/Output_tabnet_ateeq/tabnet_feature_importance_top20_h3.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6b385ff1c533638650f8b59169bdcb22fbcb1526d5202aebdbfebf53b22508df
+size 697

--- a/Output_tabnet_ateeq/tabnet_feature_importance_top20_h7.csv
+++ b/Output_tabnet_ateeq/tabnet_feature_importance_top20_h7.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:93d93fa3a1d418c159cdbe650645f8b968ea923bd067e92c42ce832334ee86e5
+size 697

--- a/Output_tabnet_ateeq/tabnet_hist3d_predictions_bins_table.csv
+++ b/Output_tabnet_ateeq/tabnet_hist3d_predictions_bins_table.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:be4f288a1624b87f5709357efbb576a144f08b14e572429e6e707504345c7e6b
+size 1029

--- a/Output_tabnet_ateeq/tabnet_hist3d_residuals_bins_table.csv
+++ b/Output_tabnet_ateeq/tabnet_hist3d_residuals_bins_table.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c11ab467406b3f6caebb33b3d479f7c1ba3805e87233abf02da69fea8d4973b0
+size 1799

--- a/Output_tabnet_ateeq/tabnet_rolling_mae_all_horizons.csv
+++ b/Output_tabnet_ateeq/tabnet_rolling_mae_all_horizons.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ad7cc053ba2683e62a1a0c90cafcc58fa2aa8ec7b7f2660d77aed70ec6793fd7
+size 3413

--- a/Output_tabnet_ateeq/tabnet_rolling_origin_cv.csv
+++ b/Output_tabnet_ateeq/tabnet_rolling_origin_cv.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b2b00d89d409f585ee400c5992190c250db36702c64569818dd88cd3c24e2706
+size 361

--- a/Output_tabnet_ateeq/tabnet_total_tickets_test.csv
+++ b/Output_tabnet_ateeq/tabnet_total_tickets_test.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f8e898f20ec58117466b5a2cf9522b48cae1ba5b34f8775bd39af95270df12d7
+size 118

--- a/Output_tabnet_ateeq/tabnet_training_curves_h1.csv
+++ b/Output_tabnet_ateeq/tabnet_training_curves_h1.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e8da3f710cadb146667c63f6deb8fdf03779f0ec627bf5198ba92c3312be1f8b
+size 1442

--- a/Output_tabnet_ateeq/tabnet_training_curves_h3.csv
+++ b/Output_tabnet_ateeq/tabnet_training_curves_h3.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:801e79bf4833d5c9042427bd8d5696124357fad9dd3b11d478e719032864046c
+size 2428

--- a/Output_tabnet_ateeq/tabnet_training_curves_h7.csv
+++ b/Output_tabnet_ateeq/tabnet_training_curves_h7.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8a3dad9ff49af3fdc874d2aacc8c6d9660d497d8bf902924922bcca08b1eadc9
+size 1182

--- a/Output_tabnet_ateeq/tabnet_training_h1.csv
+++ b/Output_tabnet_ateeq/tabnet_training_h1.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d139ecc3836ac0f0e965b35563ab833a7abd3ee66e0643c080aa61f768626f08
+size 27

--- a/Output_tabnet_ateeq/tabnet_training_h3.csv
+++ b/Output_tabnet_ateeq/tabnet_training_h3.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d139ecc3836ac0f0e965b35563ab833a7abd3ee66e0643c080aa61f768626f08
+size 27

--- a/Output_tabnet_ateeq/tabnet_training_h7.csv
+++ b/Output_tabnet_ateeq/tabnet_training_h7.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d139ecc3836ac0f0e965b35563ab833a7abd3ee66e0643c080aa61f768626f08
+size 27


### PR DESCRIPTION
This pull request adds 48 CSV output files generated from TabNet Model.

Location: Output_tabnet_ateeq/

Content: All Models Comparison, training curves, feature importance, predictions, rolling MAE, and related TabNet outputs

Tracking: All CSV files are stored using Git LFS (as configured in the repository)